### PR TITLE
fix alignment issues

### DIFF
--- a/src/image_writer.rs
+++ b/src/image_writer.rs
@@ -1,3 +1,4 @@
+use crate::error::Converter;
 use crate::paged_writer::PagedWriter;
 use crate::Blob;
 use crate::CylindricalImage;
@@ -241,6 +242,10 @@ impl<'a, T: Read + Write + Seek> ImageWriter<'a, T> {
 
         // Add metadata for XML generation later, when the file is completed.
         self.images.push(self.image.clone());
+
+        self.writer
+            .align()
+            .write_err("Failed to align writer on next 4-byte offset after writing data packet")?;
 
         Ok(())
     }

--- a/src/paged_writer.rs
+++ b/src/paged_writer.rs
@@ -93,7 +93,7 @@ impl<T: Write + Read + Seek> PagedWriter<T> {
         // If available, read existing page data
         let mut unread = &mut self.page_buffer[..];
         while !unread.is_empty() {
-            let read = self.writer.read(&mut unread)?;
+            let read = self.writer.read(unread)?;
             if read == 0 {
                 break;
             }
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn empty() {
         let path = Path::new("empty.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
         let writer = PagedWriter::new(file).unwrap();
         drop(writer);
         assert_eq!(path.metadata().unwrap().len(), 0);
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn partial_page() {
         let path = Path::new("partial.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
 
         // Write only three bytes
         let mut writer = PagedWriter::new(file).unwrap();
@@ -243,7 +243,7 @@ mod tests {
     #[test]
     fn single_page() {
         let path = Path::new("single.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Write exactly one page
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     fn multi_page() {
         let path = Path::new("multi.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Write a little bit more than one page
@@ -305,7 +305,7 @@ mod tests {
     #[test]
     fn flush_in_page() {
         let path = Path::new("flush.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Partial page
@@ -337,7 +337,7 @@ mod tests {
     #[test]
     fn seek_existing_page() {
         let path = Path::new("seek_existing.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Write two pages with ones
@@ -379,7 +379,7 @@ mod tests {
     #[test]
     fn phys_position_size() {
         let path = Path::new("phys_position_size.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Write a page and some bytes
@@ -388,7 +388,7 @@ mod tests {
 
         // We expect the physical position to be the logical + CRC size
         let pos = writer.physical_position().unwrap();
-        assert_eq!(pos, 1028 + CRC_SIZE as u64);
+        assert_eq!(pos, 1028 + CRC_SIZE);
 
         // We expect the physical size to be two pages with CRC sums
         let size = writer.physical_size().unwrap();
@@ -400,7 +400,7 @@ mod tests {
     #[test]
     fn align() {
         let path = Path::new("align.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         writer.align().unwrap();
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn short_seek_back() {
         let path = Path::new("short_seek_back.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         writer.write_all(&[4, 1, 2, 3]).unwrap();
@@ -448,7 +448,7 @@ mod tests {
     #[test]
     fn write_into_page() {
         let path = Path::new("write_into_page.bin");
-        let file = open_options().open(&path).unwrap();
+        let file = open_options().open(path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         writer.write_all(&[1; PAGE_PAYLOAD_SIZE]).unwrap();

--- a/src/paged_writer.rs
+++ b/src/paged_writer.rs
@@ -12,7 +12,7 @@ const PAGE_PAYLOAD_SIZE: usize = (PAGE_SIZE - CRC_SIZE) as usize;
 pub struct PagedWriter<T: Write + Read + Seek> {
     writer: T,
     offset: usize,
-    page_buffer: Vec<u8>,
+    page_buffer: [u8; PAGE_SIZE as usize],
 
     #[cfg(not(feature = "crc32c"))]
     crc: Crc32,
@@ -30,11 +30,10 @@ impl<T: Write + Read + Seek> PagedWriter<T> {
                 source: None,
             })?
         }
-        let page_buffer = vec![0_u8; (PAGE_SIZE - CRC_SIZE) as usize];
         Ok(Self {
             writer,
             offset: 0,
-            page_buffer,
+            page_buffer: [0_u8; PAGE_SIZE as usize],
 
             #[cfg(not(feature = "crc32c"))]
             crc: Crc32::new(),
@@ -61,11 +60,16 @@ impl<T: Write + Read + Seek> PagedWriter<T> {
             .write_err("Failed to seek to file end")?;
         let page = pos / PAGE_SIZE;
         self.offset = (pos % PAGE_SIZE) as usize;
-        self.page_buffer.fill(0_u8);
 
         if pos > end {
             Err(Error::Write {
                 desc: String::from("Cannot seek after end of file"),
+                source: None,
+            })?
+        }
+        if self.offset >= PAGE_PAYLOAD_SIZE {
+            Err(Error::Write {
+                desc: String::from("Cannot seek into checksum"),
                 source: None,
             })?
         }
@@ -75,15 +79,27 @@ impl<T: Write + Read + Seek> PagedWriter<T> {
             .seek(SeekFrom::Start(page_phys_offset))
             .write_err("Failed to seek to specified position")?;
 
+        self.populate_existing_data()
+            .write_err("Failed to read existing page data")?;
+
+        self.writer
+            .seek(SeekFrom::Start(page_phys_offset))
+            .write_err("Failed to seek back to page start after reading existing data")?;
+
+        Ok(())
+    }
+
+    fn populate_existing_data(&mut self) -> std::io::Result<()> {
         // If available, read existing page data
-        if end >= page_phys_offset + PAGE_SIZE {
-            self.writer
-                .read_exact(&mut self.page_buffer)
-                .write_err("Failed to read existing page data")?;
-            self.writer
-                .seek(SeekFrom::Start(page_phys_offset))
-                .write_err("Failed to seek back to page start after reading existing data")?;
+        let mut unread = &mut self.page_buffer[..];
+        while !unread.is_empty() {
+            let read = self.writer.read(&mut unread)?;
+            if read == 0 {
+                break;
+            }
+            unread = &mut unread[read..];
         }
+        unread.fill(0);
         Ok(())
     }
 
@@ -100,17 +116,16 @@ impl<T: Write + Read + Seek> PagedWriter<T> {
             .write_err("Cannot seek to file end")?;
         self.writer
             .seek(SeekFrom::Start(pos))
-            .write_err("Cannot seek to previois position")?;
+            .write_err("Cannot seek to previous position")?;
         Ok(size)
     }
 
     /// Write some zeros to next 4-byte-aligned offset, if needed.
     pub fn align(&mut self) -> Result<()> {
+        let zeros = [0u8; 4];
         let mod_offset = self.offset % 4;
         if mod_offset != 0 {
-            let skip = 4 - mod_offset;
-            let zeros = vec![0_u8; skip];
-            self.write_all(&zeros)
+            self.write_all(&zeros[mod_offset..])
                 .write_err("Failed to write zero bytes for alignment")?;
         }
         Ok(())
@@ -124,20 +139,22 @@ impl<T: Write + Read + Seek> Write for PagedWriter<T> {
         self.page_buffer[self.offset..self.offset + writeable_bytes]
             .copy_from_slice(&buf[..writeable_bytes]);
         self.offset += writeable_bytes;
-        if self.offset >= PAGE_PAYLOAD_SIZE {
+        if self.offset == PAGE_PAYLOAD_SIZE {
             // Simple & slower default included SW implementation
             #[cfg(not(feature = "crc32c"))]
-            let crc = self.crc.calculate(&self.page_buffer);
+            let crc = self.crc.calculate(&self.page_buffer[..PAGE_PAYLOAD_SIZE]);
 
             // Optional faster external crate with HW support
             #[cfg(feature = "crc32c")]
-            let crc = crc32c::crc32c(&self.page_buffer);
+            let crc = crc32c::crc32c(&self.page_buffer[..PAGE_PAYLOAD_SIZE]);
 
-            self.page_buffer.extend_from_slice(&crc.to_be_bytes());
+            self.page_buffer[PAGE_PAYLOAD_SIZE..].copy_from_slice(&crc.to_be_bytes());
             self.writer.write_all(&self.page_buffer)?;
-            self.page_buffer.resize(PAGE_PAYLOAD_SIZE, 0_u8);
-            self.page_buffer.fill(0_u8);
+
+            let page_phys_offset = self.writer.stream_position()?;
             self.offset = 0;
+            self.populate_existing_data()?;
+            self.writer.seek(SeekFrom::Start(page_phys_offset))?;
         }
         Ok(writeable_bytes)
     }
@@ -145,23 +162,22 @@ impl<T: Write + Read + Seek> Write for PagedWriter<T> {
     fn flush(&mut self) -> std::io::Result<()> {
         // If the page buffer is empty we do not need to persist it
         if self.offset > 0 {
-            // Store start posotion of current page
+            // Store start position in current page
             let pos = self.writer.stream_position()?;
 
             // Simple & slower default included SW implementation
             #[cfg(not(feature = "crc32c"))]
-            let crc = self.crc.calculate(&self.page_buffer);
+            let crc = self.crc.calculate(&self.page_buffer[..PAGE_PAYLOAD_SIZE]);
 
             // Optional faster external crate with HW support
             #[cfg(feature = "crc32c")]
-            let crc = crc32c::crc32c(&self.page_buffer);
+            let crc = crc32c::crc32c(&self.page_buffer[..PAGE_PAYLOAD_SIZE]);
 
             // Write current page
-            self.page_buffer.extend_from_slice(&crc.to_be_bytes());
+            self.page_buffer[PAGE_PAYLOAD_SIZE..].copy_from_slice(&crc.to_be_bytes());
             self.writer.write_all(&self.page_buffer)?;
-            self.page_buffer.truncate(PAGE_PAYLOAD_SIZE);
 
-            // Seek back to beginning of the page
+            // Seek back to start position
             self.writer.seek(SeekFrom::Start(pos))?;
         }
 
@@ -181,13 +197,19 @@ impl<T: Write + Read + Seek> Drop for PagedWriter<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::{remove_file, File, OpenOptions};
+    use std::fs::{remove_file, OpenOptions};
     use std::path::Path;
+
+    fn open_options() -> OpenOptions {
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create(true).truncate(true);
+        options
+    }
 
     #[test]
     fn empty() {
         let path = Path::new("empty.bin");
-        let file = File::create(&path).unwrap();
+        let file = open_options().open(&path).unwrap();
         let writer = PagedWriter::new(file).unwrap();
         drop(writer);
         assert_eq!(path.metadata().unwrap().len(), 0);
@@ -197,7 +219,7 @@ mod tests {
     #[test]
     fn partial_page() {
         let path = Path::new("partial.bin");
-        let file = File::create(&path).unwrap();
+        let file = open_options().open(&path).unwrap();
 
         // Write only three bytes
         let mut writer = PagedWriter::new(file).unwrap();
@@ -221,7 +243,7 @@ mod tests {
     #[test]
     fn single_page() {
         let path = Path::new("single.bin");
-        let file = File::create(&path).unwrap();
+        let file = open_options().open(&path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Write exactly one page
@@ -243,7 +265,7 @@ mod tests {
     #[test]
     fn multi_page() {
         let path = Path::new("multi.bin");
-        let file = File::create(&path).unwrap();
+        let file = open_options().open(&path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Write a little bit more than one page
@@ -283,7 +305,7 @@ mod tests {
     #[test]
     fn flush_in_page() {
         let path = Path::new("flush.bin");
-        let file = File::create(&path).unwrap();
+        let file = open_options().open(&path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Partial page
@@ -314,13 +336,8 @@ mod tests {
 
     #[test]
     fn seek_existing_page() {
-        let mut options = OpenOptions::new();
-        options.read(true);
-        options.write(true);
-        options.create(true);
-        options.truncate(true);
         let path = Path::new("seek_existing.bin");
-        let file = options.open(&path).unwrap();
+        let file = open_options().open(&path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Write two pages with ones
@@ -347,13 +364,7 @@ mod tests {
     #[test]
     fn seek_after_end() {
         let path = Path::new("seek_after_end.bin");
-        let file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .read(true)
-            .truncate(true)
-            .open(path)
-            .unwrap();
+        let file = open_options().open(path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Seek to start should work
@@ -368,7 +379,7 @@ mod tests {
     #[test]
     fn phys_position_size() {
         let path = Path::new("phys_position_size.bin");
-        let file = File::create(&path).unwrap();
+        let file = open_options().open(&path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         // Write a page and some bytes
@@ -389,7 +400,7 @@ mod tests {
     #[test]
     fn align() {
         let path = Path::new("align.bin");
-        let file = File::create(&path).unwrap();
+        let file = open_options().open(&path).unwrap();
         let mut writer = PagedWriter::new(file).unwrap();
 
         writer.align().unwrap();
@@ -407,6 +418,65 @@ mod tests {
         assert_eq!(content[1], 1_u8);
         assert_eq!(content[2], 0_u8);
         assert_eq!(content[3], 0_u8);
+
+        remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn short_seek_back() {
+        let path = Path::new("short_seek_back.bin");
+        let file = open_options().open(&path).unwrap();
+        let mut writer = PagedWriter::new(file).unwrap();
+
+        writer.write_all(&[4, 1, 2, 3]).unwrap();
+        // This seek places the cursor within an incomplete page.
+        writer.physical_seek(0).unwrap();
+        writer.write_all(&[0]).unwrap();
+        writer.flush().unwrap();
+
+        // Check file content
+        drop(writer);
+        let content = std::fs::read(path).unwrap();
+        assert_eq!(content[0], 0_u8);
+        assert_eq!(content[1], 1_u8);
+        assert_eq!(content[2], 2_u8);
+        assert_eq!(content[3], 3_u8);
+
+        remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn write_into_page() {
+        let path = Path::new("write_into_page.bin");
+        let file = open_options().open(&path).unwrap();
+        let mut writer = PagedWriter::new(file).unwrap();
+
+        writer.write_all(&[1; PAGE_PAYLOAD_SIZE]).unwrap();
+        writer.write_all(&[2; PAGE_PAYLOAD_SIZE]).unwrap();
+        writer.physical_seek(PAGE_PAYLOAD_SIZE as u64 - 1).unwrap();
+        // These two bytes span a page boundary.
+        writer.write_all(&[3; 2]).unwrap();
+        writer.flush().unwrap();
+
+        // Check file content
+        drop(writer);
+        let content = std::fs::read(path).unwrap();
+        for i in 0..PAGE_PAYLOAD_SIZE - 1 {
+            assert_eq!(
+                content[i], 1_u8,
+                "Expected 1 at {} but got {}",
+                i, content[i],
+            );
+        }
+        assert_eq!(3, content[PAGE_PAYLOAD_SIZE - 1]);
+        assert_eq!(3, content[PAGE_SIZE as usize]);
+        for i in PAGE_SIZE as usize + 1..(PAGE_SIZE as usize + PAGE_PAYLOAD_SIZE) {
+            assert_eq!(
+                content[i], 2_u8,
+                "Expected 2 at {} but got {}",
+                i, content[i],
+            );
+        }
 
         remove_file(path).unwrap();
     }

--- a/tests/reader_tests.rs
+++ b/tests/reader_tests.rs
@@ -69,7 +69,7 @@ fn creation() {
     let reader = E57Reader::from_file("testdata/bunnyDouble.e57").unwrap();
     let creation = reader.creation().unwrap();
     assert_eq!(creation.gps_time, 987369380.8049808);
-    assert_eq!(creation.atomic_reference, false);
+    assert!(!creation.atomic_reference);
 }
 
 #[test]
@@ -157,9 +157,9 @@ fn cartesian_bounds() {
     let bounds = pc.cartesian_bounds.as_ref().unwrap();
     assert_eq!(bounds.x_min, Some(-9.779529571533203));
     assert_eq!(bounds.x_max, Some(-6.774238109588623));
-    assert_eq!(bounds.y_min, Some(4.5138792991638184));
-    assert_eq!(bounds.y_max, Some(7.5154604911804199));
-    assert_eq!(bounds.z_min, Some(295.52468872070312));
+    assert_eq!(bounds.y_min, Some(4.513_879_299_163_818));
+    assert_eq!(bounds.y_max, Some(7.515_460_491_180_42));
+    assert_eq!(bounds.z_min, Some(295.524_688_720_703_1));
     assert_eq!(bounds.z_max, Some(298.53216552734375));
 }
 

--- a/tests/writer_tests.rs
+++ b/tests/writer_tests.rs
@@ -602,7 +602,7 @@ fn write_read_meta_data() {
         let e57_reader = E57Reader::from_file(out_path).unwrap();
         let creation = e57_reader.creation().unwrap();
         assert_eq!(creation.gps_time, 12.34);
-        assert_eq!(creation.atomic_reference, true);
+        assert!(creation.atomic_reference);
         assert_eq!(e57_reader.coordinate_metadata(), Some("coord meta"));
         let library_version = e57_reader.library_version().unwrap();
         assert!(library_version.contains("Rust E57 Library"));
@@ -621,10 +621,10 @@ fn write_read_meta_data() {
         assert_eq!(pc.original_guids, Some(guids));
         let start = pc.acquisition_start.unwrap();
         assert_eq!(start.gps_time, 0.0);
-        assert_eq!(start.atomic_reference, false);
+        assert!(!start.atomic_reference);
         let end = pc.acquisition_end.unwrap();
         assert_eq!(end.gps_time, 1.23);
-        assert_eq!(end.atomic_reference, false);
+        assert!(!end.atomic_reference);
         assert_eq!(pc.temperature, Some(23.0));
         assert_eq!(pc.humidity, Some(66.6));
         assert_eq!(pc.atmospheric_pressure, Some(1337.0));


### PR DESCRIPTION
- A test is added for seeking backwards into the current page. This always worked because the page is flushed before seeking, effectively making the current page a previous page.
- A test is added for performing a write that crosses from one written page into another written page, and the implementation is fixed such that the second written page is not zeroed. This requires that the output stream is seekable when writing more than one page, but writing e57 files already requires that the output stream be seekable so this shouldn't be a problem.
- The PagedWriter no longer allocates any vectors.
- The writer is aligned after writing images. I'm pretty sure the C++ implementation expects this.